### PR TITLE
feat: Add MAGIC (Cosmic Universe Missing Primary Token)

### DIFF
--- a/build/defikingdoms-community.tokenlist.json
+++ b/build/defikingdoms-community.tokenlist.json
@@ -1,9 +1,9 @@
 {
   "name": "DFK Community",
-  "timestamp": "2022-04-20T05:19:55.752Z",
+  "timestamp": "2022-04-28T18:15:50.570Z",
   "version": {
     "major": 6,
-    "minor": 3,
+    "minor": 4,
     "patch": 0
   },
   "tags": {},
@@ -132,6 +132,14 @@
       "name": "Kuro Shiba",
       "decimals": 9,
       "logoURI": "https://firebasestorage.googleapis.com/v0/b/defi-kingdoms.appspot.com/o/tokens%2FKURO.png?alt=media"
+    },
+    {
+      "chainId": 1666600000,
+      "address": "0x892D81221484F690C0a97d3DD18B9144A3ECDFB7",
+      "symbol": "MAGIC",
+      "name": "Magic",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/19313/large/13037.png?1635025843"
     },
     {
       "chainId": 1666600000,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@defikingdoms/community-token-list",
-  "version": "6.3.0",
+  "version": "6.4.0",
   "description": "◦ The Defi Kingdoms default token list",
   "main": "build/defikingdoms-community.tokenlist.json",
   "scripts": {

--- a/src/tokens/harmony-mainnet.json
+++ b/src/tokens/harmony-mainnet.json
@@ -57,6 +57,14 @@
   },
   {
     "chainId": 1666600000,
+    "address": "0x892D81221484F690C0a97d3DD18B9144A3ECDFB7",
+    "symbol": "MAGIC",
+    "name": "Magic",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/19313/large/13037.png?1635025843"
+  },
+  {
+    "chainId": 1666600000,
     "address": "0x6008C8769BFACd92251bA838382e7e5637C7e74D",
     "symbol": "COSMIC",
     "name": "Cosmic Coin",


### PR DESCRIPTION
This PR adds the MAGIC token from Cosmic Universe. The Cosmic Coin token has been part of the list for a long time.

**Coin purposes**
COSMIC - P2E Token
MAGIC - Governance Token

**Checklist**
[x] - Added the token, including an image, and a checksummed address
[x] - Ran a passing test
[x] - Bumped the version
[x] - Ran a build updating the community tokenlist build output

Thanks!
